### PR TITLE
bump pvgis api endpoint to version 5.3 and some errorhandling changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,171 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# PyPI configuration file
+.pypirc

--- a/examples/hourly_example.py
+++ b/examples/hourly_example.py
@@ -1,0 +1,6 @@
+from pvgispy import Hourly
+
+hourly = Hourly(lat=51, lon=9, pvcalculation=True, loss=20, peakpower=100,
+                        angle=0, aspect=-180, startyear=2010, endyear=2012)
+
+print(hourly.yearly_pv_production())

--- a/examples/hourly_example.py
+++ b/examples/hourly_example.py
@@ -1,6 +1,0 @@
-from pvgispy import Hourly
-
-hourly = Hourly(lat=51, lon=9, pvcalculation=True, loss=20, peakpower=100,
-                        angle=0, aspect=-180, startyear=2010, endyear=2012)
-
-print(hourly.yearly_pv_production())

--- a/examples/pandas_example.py
+++ b/examples/pandas_example.py
@@ -1,0 +1,28 @@
+from pvgispy import Hourly, TMY
+import pandas as pd
+
+hourly = Hourly(
+    lat=51.0,
+    lon=9.0,
+    angle=0, # inclination angle from horizontal plane
+    aspect=-180, # Orientation (azimuth) angle of the (fixed) plane, 0=south, 90=west, -90=east. Not relevant for tracking planes.
+    startyear=2020,
+    endyear=2023,
+    pvcalculation=False, # disable pv claulations, we only want radiation data
+)
+
+df_hourly = pd.json_normalize(hourly.hourly())
+
+print(df_hourly.head())
+
+# uncomment the line below to safe the DAtaFrame as a CSV fiel
+# df.to_csv("hourly.csv")
+
+tmy = TMY(
+    lat=51.0,
+    lon=9.0,
+)
+
+df_tmy = pd.json_normalize(tmy.hourly())
+
+print(df_tmy.head())

--- a/examples/pv_calulation.py
+++ b/examples/pv_calulation.py
@@ -1,0 +1,16 @@
+from pvgispy import Hourly
+
+hourly = Hourly(
+    lat=51.0,
+    lon=9.0,
+    angle=0, # inclination angle from horizontal plane
+    aspect=-180, # Orientation (azimuth) angle of the (fixed) plane, 0=south, 90=west, -90=east. Not relevant for tracking planes.
+    startyear=2020,
+    endyear=2023,
+    pvcalculation=True, # enable pv calulations
+    peakpower=1000.0,
+    loss=20.0
+)
+
+
+print(hourly.irradiance(as_list=True))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="pvgispy",
-    version="0.1.2",
+    version="0.1.3",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     install_requires=[

--- a/src/pvgispy/base.py
+++ b/src/pvgispy/base.py
@@ -3,7 +3,8 @@ import requests
 
 
 class BaseAPI:
-    BASE_URL = "https://re.jrc.ec.europa.eu/api/v5_2/"
+    BASE_URL = "https://re.jrc.ec.europa.eu/api/v5_3/"
+    BASE_URL_V2 = "https://re.jrc.ec.europa.eu/api/v5_2/"
     BASE_URL_V1 = "https://re.jrc.ec.europa.eu/api/v5_1/"
 
     def __init__(self, lat: float, lon: float,  **kwargs):

--- a/src/pvgispy/daily.py
+++ b/src/pvgispy/daily.py
@@ -64,7 +64,7 @@ class Daily(BaseAPI):
             "lon": self.lon,
             "month": self.month,
             "usehorizon": self._params.get("usehorizon", 1),
-            "raddatabase": self._params.get("raddatabase", "PVGIS-SARAH2"),
+            "raddatabase": self._params.get("raddatabase", "PVGIS-SARAH5"),
             "angle": self._params.get("angle", 0),
             "aspect": self._params.get("aspect", 0),
             "global": self._params.get("global", 1),

--- a/src/pvgispy/daily.py
+++ b/src/pvgispy/daily.py
@@ -18,7 +18,7 @@ class Daily(BaseAPI):
         Optional parameters:
         :param usehorizon: (Optional) Calculate considering shadows from a high horizon. Default is 1 for "yes".
         :param userhorizon: (Optional) Height of the horizon at equidistant directions around the point of interest, in degrees. Starting at north and moving clockwise. The series '0,10,20,30,40,15,25,5' would mean the horizon height is 0° due north, 10° for north-east, 20° for east, 30° for south-east, etc.
-        :param raddatabase
+        :param raddatabase: Name of the radiation database. "PVGIS-SARAH" for Europe, Africa and Asia or "PVGIS-NSRDB" for the Americas between 60°N and 20°S, "PVGIS-ERA5" and "PVGIS-COSMO" for Europe (including high-latitudes), and "PVGIS-CMSAF" for Europe and Africa (will be deprecated)
         :param angle
         :param aspect
         :param global
@@ -64,7 +64,7 @@ class Daily(BaseAPI):
             "lon": self.lon,
             "month": self.month,
             "usehorizon": self._params.get("usehorizon", 1),
-            "raddatabase": self._params.get("raddatabase", "PVGIS-SARAH5"),
+            "raddatabase": self._params.get("raddatabase", "PVGIS-SARAH3"),
             "angle": self._params.get("angle", 0),
             "aspect": self._params.get("aspect", 0),
             "global": self._params.get("global", 1),

--- a/src/pvgispy/hourly.py
+++ b/src/pvgispy/hourly.py
@@ -34,10 +34,10 @@ class Hourly(BaseAPI):
 
         if endyear < startyear:
             raise ValueError("Incorrect time period. The calculation period for this app should be at least 1 years.")
-        if startyear not in range(2005, 2020):
+        if startyear not in range(2005, 2023):
             raise ValueError("Incorrect start year. Please, enter an integer between 2005 and 2016.")
         self.startyear = startyear
-        if endyear not in range(2005, 2020):
+        if endyear not in range(2005, 2023):
             raise ValueError("Incorrect end year. Please, enter an integer between 2005 and 2016.")
         self.endyear = endyear
 

--- a/src/pvgispy/hourly.py
+++ b/src/pvgispy/hourly.py
@@ -34,26 +34,27 @@ class Hourly(BaseAPI):
 
         if endyear < startyear:
             raise ValueError("Incorrect time period. The calculation period for this app should be at least 1 years.")
-        if startyear not in range(2005, 2023):
-            raise ValueError("Incorrect start year. Please, enter an integer between 2005 and 2016.")
+        if startyear not in range(2005, 2024):
+            raise ValueError("Incorrect start year. Please, enter an integer between 2005 and 2023.")
         self.startyear = startyear
-        if endyear not in range(2005, 2023):
-            raise ValueError("Incorrect end year. Please, enter an integer between 2005 and 2016.")
+        if endyear not in range(2005, 2024):
+            raise ValueError("Incorrect end year. Please, enter an integer between 2005 and 2023.")
         self.endyear = endyear
 
-        if pvcalculation and peakpower is None:
-            raise ValueError("Invalid peak-power. If pvcalculation set True, peakpower can't be None.")
-        self.peakpower = peakpower
+        if pvcalculation:
+            if pvcalculation and peakpower is None:
+                raise ValueError("Invalid peak-power. If pvcalculation set True, peakpower can't be None.")
+            self.peakpower = peakpower
 
-        if pvcalculation and loss is None:
-            raise ValueError("Invalid loss. If pvcalculation set True, loss can't be None.")
-        if int(loss) not in range(0, 100):
-            raise ValueError("Invalid loss value. Please, enter a float between 0 and 100.")
-        self.loss = loss
+            if pvcalculation and loss is None:
+                raise ValueError("Invalid loss. If pvcalculation set True, loss can't be None.")
+            if int(loss) not in range(0, 100):
+                raise ValueError("Invalid loss value. Please, enter a float between 0 and 100.")
+            self.loss = loss
 
-        if pvtech not in ["crystSi", "CIS", "CdTe", "Unknown"]:
-            raise ValueError("Invalid PV Technology. Valid technologies are 'crystSi', 'CIS', 'CdTe', 'Unknown'")
-        self.pvtech = pvtech
+            if pvtech not in ["crystSi", "CIS", "CdTe", "Unknown"]:
+                raise ValueError("Invalid PV Technology. Valid technologies are 'crystSi', 'CIS', 'CdTe', 'Unknown'")
+            self.pvtech = pvtech
 
         if int(angle) not in range(0, 91):
             raise ValueError("Invalid angle. Please, enter a float between 0 and 90.")
@@ -86,14 +87,14 @@ class Hourly(BaseAPI):
             "lat": self.lat,
             "lon": self.lon,
             "usehorizon": self._params.get("usehorizon", 1),
-            "raddatabase": self._params.get("raddatabase", "PVGIS-SARAH2"),
+            "raddatabase": self._params.get("raddatabase", "PVGIS-SARAH3"),
             "startyear": self.startyear,
             "endyear": self.endyear,
             "pvcalculation": 1 if self.pvcalculation else 0,
-            "peakpower": self.peakpower,
-            "pvtechchoice": self.pvtech,
+            "peakpower": self.peakpower if self.pvcalculation else None,
+            "pvtechchoice": self.pvtech if self.pvcalculation else None,
             "mountingplace": self._params.get("mountingplace", None),
-            "loss": self.loss,
+            "loss": self.loss if self.pvcalculation else None,
             "trackingtype": self._params.get("trackingtype", None),
             "angle": self.angle,
             "aspect": self.aspect,

--- a/src/pvgispy/tmy.py
+++ b/src/pvgispy/tmy.py
@@ -12,6 +12,11 @@ class TMY(BaseAPI):
         :param lat: Latitude in decimal degrees (south is negative).
         :param lon: Longitude in decimal degrees (west is negative).
 
+        Optional parameters:
+        :param startyear: First year of the TMY. Availability depends on the temporal coverage of the radiation DB chosen. The default value is the first year of the DB chosen.
+        :param endyear: Final year of the TMY. Availability depends on the temporal coverage of the radiation DB chosen. The default value is the last year of the DB chosen. The period defined by startyear, endyear should be >= 10 years.
+        :param raddatabase: The Database used to calculate the tmy. either PVGIS-ERA5 or PVGIS-SARAH3, default is PVGIS-SARAH3.
+        
         Describes the various output variables from the API call:
 
         - `G(h)`: Global irradiance on the horizontal plane (units: W/m2).
@@ -50,7 +55,8 @@ class TMY(BaseAPI):
             "startyear": self._params.get("startyear", None),
             "endyear": self._params.get("endyear", None),
             "outputformat": self._params.get("outputformat", "json"),
-            "browser": self._params.get("browser", 0)
+            "browser": self._params.get("browser", 0),
+            "raddatabase": self._params.get("raddatabase", "PVGIS-SARAH3")
         }
 
         # Remove any parameters set to None


### PR DESCRIPTION
# Update to API v5.3 with New Features and Deprecation Adjustments

## Description
- Updated code to use API version 5.3, replacing the soon-to-be-deprecated v5.2.
- Added an example directory for easier integration and testing.
- Updated default values and introduced new radiation databases.

## Important Notes
- This update might not be fully backwards compatible. If users had manually configured the database for v5.2, there could be failures due to changes in available databases.

## Request for Review
@jannikobenhoff , please review these changes for compatibility and overall integration.