### PR TITLE
workflow for automated upload to pypi when a release is published

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,39 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ from setuptools import setup, find_packages
 setup(
     name="pvgispy",
     version="0.1.3",
+    description="An inofficial interface for the PVGIS API by the EU Science Hub",
+    url="https://github.com/jannikobenhoff/pvgispy",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     install_requires=[


### PR DESCRIPTION
This Github Actions Workflow automatically uploads the library to pypi using a github action when a new release is published on github. I used the same workflow file myself when i tried doing automated publishing the first time: https://github.com/lumagician/sampy

@jannikobenhoff this would require you to create a github secret with your pypi api token.

the name has to be exactly `PYPI_API_TOKEN`.